### PR TITLE
Implement CLI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@
 scalaVersion := "2.12.7"
 
 lazy val akkaVersion = "2.5.17"
+lazy val clistVersion = "3.5.0"
 
 lazy val hasher = project
   .in(file("."))
@@ -12,6 +13,8 @@ lazy val hasher = project
     name := "hasher",
     version := "0.0.1",
     libraryDependencies ++= Seq(
+      "org.backuity.clist" %% "clist-core" % clistVersion,
+      "org.backuity.clist" %% "clist-macros" % clistVersion % "provided",
       "com.typesafe.akka" %% "akka-actor" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,

--- a/src/main/scala/com/github/leananeuber/hasher/HasherActorSystem.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/HasherActorSystem.scala
@@ -11,32 +11,6 @@ import scala.language.postfixOps
 
 object HasherActorSystem {
 
-  val actorSystemName = "akka-actor-party"
-  val masterRole = "master"
-  val slaveRole = "slave"
-
-  def main(args: Array[String]): Unit = {
-    val system = actorSystem(actorSystemName, configuration(
-      actorSystemName,
-      masterRole,
-      "localhost",
-      2551,
-      "localhost",
-      2551
-    ))
-    val cluster = Cluster(system)
-
-    // run example code on status UP
-    cluster.registerOnMemberUp{
-      AkkaQuickstart.runQuickstartExampleOn(system)
-    }
-
-    // leave cluster after 2 seconds
-    system.scheduler.scheduleOnce(2 seconds) {
-      cluster.leave(cluster.selfAddress)
-    }
-  }
-
   def configuration(actorSystemName: String, actorSystemRole: String, host: String, port: Int, masterHost: String, masterPort: Int): Config = {
     ConfigFactory.parseString(
       s"""akka.remote.artery.canonical.hostname = "$host"

--- a/src/main/scala/com/github/leananeuber/hasher/HasherApp.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/HasherApp.scala
@@ -1,0 +1,19 @@
+package com.github.leananeuber.hasher
+
+import com.github.leananeuber.hasher.cli.{StartMasterCommand, StartSlaveCommand}
+import org.backuity.clist.Cli
+
+object HasherApp {
+
+  val actorSystemName = "akka-actor-party"
+
+  def main(args: Array[String]): Unit = {
+    Cli.parse(args)
+      .withProgramName("akka-actor-party")
+      .withDescription("Analyze student record for passwords and genetic codes to mine hashes.")
+      .version("0.0.1")
+      .withCommands(StartMasterCommand, StartSlaveCommand)
+      .foreach(_.run(actorSystemName))
+  }
+
+}

--- a/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
@@ -11,6 +11,7 @@ object CommonStartCommand {
   val defaultMasterPort = 7877
   val defaultSlavePort = 7879
   val defaultNWorkers = 4
+  val defaultNSlaves = 0
 }
 
 trait CommonStartCommand { this: clist.Command =>

--- a/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
@@ -1,0 +1,41 @@
+package com.github.leananeuber.hasher.cli
+
+import java.net.InetAddress
+
+import org.backuity.clist
+
+import scala.util.Try
+
+object CommonStartCommand {
+
+  val defaultMasterPort: Int = 7877
+  val defaultSlavePort: Int = 7879
+  val defaultNWorkers: Int = 4
+}
+
+trait CommonStartCommand { this: clist.Command =>
+  var host: String = clist.opt[String](
+    abbrev = "h",
+    description = "this machine's host name or IP to bind against",
+    default = defaultHost
+  )
+
+  var port: Int = clist.opt[Int](
+    abbrev = "p",
+    description = "port to bind against",
+    default = defaultPort
+  )
+
+  var nWorkers: Int = clist.opt[Int](
+    name = "workers",
+    abbrev = "w",
+    description = "number of workers to start locally",
+    default = CommonStartCommand.defaultNWorkers
+  )
+
+  def defaultHost: String = Try{
+    InetAddress.getLocalHost.getHostAddress
+  }.getOrElse("localhost")
+
+  def defaultPort: Int
+}

--- a/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/CommonStartCommand.scala
@@ -8,27 +8,24 @@ import scala.util.Try
 
 object CommonStartCommand {
 
-  val defaultMasterPort: Int = 7877
-  val defaultSlavePort: Int = 7879
-  val defaultNWorkers: Int = 4
+  val defaultMasterPort = 7877
+  val defaultSlavePort = 7879
+  val defaultNWorkers = 4
 }
 
 trait CommonStartCommand { this: clist.Command =>
   var host: String = clist.opt[String](
-    abbrev = "h",
     description = "this machine's host name or IP to bind against",
     default = defaultHost
   )
 
   var port: Int = clist.opt[Int](
-    abbrev = "p",
     description = "port to bind against",
     default = defaultPort
   )
 
   var nWorkers: Int = clist.opt[Int](
     name = "workers",
-    abbrev = "w",
     description = "number of workers to start locally",
     default = CommonStartCommand.defaultNWorkers
   )
@@ -38,4 +35,6 @@ trait CommonStartCommand { this: clist.Command =>
   }.getOrElse("localhost")
 
   def defaultPort: Int
+
+  def run(actorSystemName: String): Unit
 }

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
@@ -2,8 +2,13 @@ package com.github.leananeuber.hasher.cli
 
 import java.io.File
 
+import akka.cluster.Cluster
+import com.github.leananeuber.hasher.{AkkaQuickstart, HasherActorSystem}
 import org.backuity.clist
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 object StartMasterCommand extends clist.Command(
     name = "master",
@@ -25,6 +30,37 @@ object StartMasterCommand extends clist.Command(
   override def defaultPort: Int = CommonStartCommand.defaultMasterPort
 
   override def run(actorSystemName: String): Unit = {
+    val masterHost = host
+    val masterPort = port
+    val system = HasherActorSystem.actorSystem(actorSystemName, HasherActorSystem.configuration(
+      actorSystemName,
+      masterRole,
+      host,
+      port,
+      masterHost,
+      masterPort
+    ))
+    val cluster = Cluster(system)
 
+    // TODO: handle cluster events
+
+    // TODO: start processing
+    cluster.registerOnMemberUp{
+      // create actors
+      // read `input`
+      // start processing
+    }
+
+    // TODO: remove
+    //------------------------------------------------
+    // run example code on status UP
+    cluster.registerOnMemberUp{
+      AkkaQuickstart.runQuickstartExampleOn(system)
+    }
+    // leave cluster after 2 seconds
+    system.scheduler.scheduleOnce(2 seconds) {
+      cluster.leave(cluster.selfAddress)
+    }
+    //------------------------------------------------
   }
 }

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
@@ -3,9 +3,15 @@ package com.github.leananeuber.hasher.cli
 import org.backuity.clist
 
 
-class StartMasterCommand extends clist.Command(
+object StartMasterCommand extends clist.Command(
     name = "master",
     description = "start a master actor system") with CommonStartCommand {
 
+  val masterRole = "master"
+
   override def defaultPort: Int = CommonStartCommand.defaultMasterPort
+
+  override def run(actorSystemName: String): Unit = {
+
+  }
 }

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
@@ -1,5 +1,7 @@
 package com.github.leananeuber.hasher.cli
 
+import java.io.File
+
 import org.backuity.clist
 
 
@@ -8,6 +10,17 @@ object StartMasterCommand extends clist.Command(
     description = "start a master actor system") with CommonStartCommand {
 
   val masterRole = "master"
+
+  var nSlaves: Int = clist.opt[Int](
+    name = "slaves",
+    description = "number of slave actor systems to wait for",
+    default = CommonStartCommand.defaultNSlaves
+  )
+
+  var input: File = clist.arg[File](
+    name = "input",
+    description = "path to the input CSV file"
+  )
 
   override def defaultPort: Int = CommonStartCommand.defaultMasterPort
 

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartMasterCommand.scala
@@ -1,0 +1,11 @@
+package com.github.leananeuber.hasher.cli
+
+import org.backuity.clist
+
+
+class StartMasterCommand extends clist.Command(
+    name = "master",
+    description = "start a master actor system") with CommonStartCommand {
+
+  override def defaultPort: Int = CommonStartCommand.defaultMasterPort
+}

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
@@ -1,0 +1,25 @@
+package com.github.leananeuber.hasher.cli
+
+import org.backuity.clist
+
+
+class StartSlaveCommand extends clist.Command(
+  name = "slave",
+  description = "start a slave actor system") with CommonStartCommand {
+
+  var masterHost: String = clist.opt[String](
+    name = "masterhost",
+    abbrev = "mh",
+    description = "host name or IP of the master",
+    default = defaultHost
+  )
+
+  var masterPort: Int = clist.opt[Int](
+    name = "masterport",
+    abbrev = "mp",
+    description = "port to bind against",
+    default = CommonStartCommand.defaultMasterPort
+  )
+
+  override def defaultPort: Int = CommonStartCommand.defaultSlavePort
+}

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
@@ -3,23 +3,27 @@ package com.github.leananeuber.hasher.cli
 import org.backuity.clist
 
 
-class StartSlaveCommand extends clist.Command(
+object StartSlaveCommand extends clist.Command(
   name = "slave",
   description = "start a slave actor system") with CommonStartCommand {
 
+  val slaveRole = "slave"
+
   var masterHost: String = clist.opt[String](
     name = "masterhost",
-    abbrev = "mh",
     description = "host name or IP of the master",
     default = defaultHost
   )
 
   var masterPort: Int = clist.opt[Int](
     name = "masterport",
-    abbrev = "mp",
     description = "port to bind against",
     default = CommonStartCommand.defaultMasterPort
   )
 
   override def defaultPort: Int = CommonStartCommand.defaultSlavePort
+
+  override def run(actorSystemName: String): Unit = {
+
+  }
 }

--- a/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/cli/StartSlaveCommand.scala
@@ -1,7 +1,10 @@
 package com.github.leananeuber.hasher.cli
 
+import akka.cluster.Cluster
+import com.github.leananeuber.hasher.HasherActorSystem
 import org.backuity.clist
 
+import scala.language.postfixOps
 
 object StartSlaveCommand extends clist.Command(
   name = "slave",
@@ -24,6 +27,19 @@ object StartSlaveCommand extends clist.Command(
   override def defaultPort: Int = CommonStartCommand.defaultSlavePort
 
   override def run(actorSystemName: String): Unit = {
+    val system = HasherActorSystem.actorSystem(actorSystemName, HasherActorSystem.configuration(
+      actorSystemName,
+      slaveRole,
+      host,
+      port,
+      masterHost,
+      masterPort
+    ))
+    val cluster = Cluster(system)
 
+    // TODO: start processing
+    cluster.registerOnMemberUp{
+      // create actors
+    }
   }
 }


### PR DESCRIPTION
- Two commands: `master` and `slave`
- For the used CLI-lib, see: [clist README](https://github.com/backuity/clist)
- closes #8
- **missing**: master program terminal outputs, because these depend on the actual implementation of our processing logic, new issue: #11 