### PR TITLE
Own settings

### DIFF
--- a/src/main/resources/akkaActorParty.conf
+++ b/src/main/resources/akkaActorParty.conf
@@ -1,0 +1,12 @@
+com.github.leananeuber.hasher {
+
+  linearization-partitions = 1000
+
+  password-range {
+    start = 100000
+    end = 1000000
+  }
+
+  prefix-length = 5
+
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,5 @@
+include "akkaActorParty.conf"
+
 akka {
 
   actor {

--- a/src/main/scala/com/github/leananeuber/hasher/Settings.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/Settings.scala
@@ -1,0 +1,28 @@
+package com.github.leananeuber.hasher
+
+import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
+import com.typesafe.config.Config
+
+
+class SettingsImpl(config: Config) extends Extension {
+
+  private val namespace = "com.github.leananeuber.hasher"
+
+  val linearizationPartitions: Int = config.getInt(s"$namespace.linearization-partitions")
+
+  val prefixLength: Int = config.getInt(s"$namespace.perfix-length")
+
+  val passwordRangeStart: Int = config.getInt(s"$namespace.password-range.start")
+
+  val passwordRangeEnd: Int = config.getInt(s"$namespace.password-range.end")
+
+}
+
+
+object Settings extends ExtensionId[SettingsImpl] with ExtensionIdProvider {
+
+  override def createExtension(system: ExtendedActorSystem): SettingsImpl = new SettingsImpl(system.settings.config)
+
+  override def lookup(): ExtensionId[_ <: Extension] = Settings
+
+}

--- a/src/main/scala/com/github/leananeuber/hasher/Settings.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/Settings.scala
@@ -10,7 +10,7 @@ class SettingsImpl(config: Config) extends Extension {
 
   val linearizationPartitions: Int = config.getInt(s"$namespace.linearization-partitions")
 
-  val prefixLength: Int = config.getInt(s"$namespace.perfix-length")
+  val prefixLength: Int = config.getInt(s"$namespace.prefix-length")
 
   val passwordRangeStart: Int = config.getInt(s"$namespace.password-range.start")
 

--- a/src/main/scala/com/github/leananeuber/hasher/actors/password_cracking/PasswordCrackingMaster.scala
+++ b/src/main/scala/com/github/leananeuber/hasher/actors/password_cracking/PasswordCrackingMaster.scala
@@ -1,6 +1,7 @@
 package com.github.leananeuber.hasher.actors.password_cracking
 
 import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill, Props}
+import com.github.leananeuber.hasher.Settings
 import com.github.leananeuber.hasher.actors.Reaper
 import com.github.leananeuber.hasher.actors.password_cracking.PasswordCrackingProtocol.{CrackPasswordsCommand, PasswordsCrackedEvent, StartCrackingCommand}
 import com.github.leananeuber.hasher.protocols.MasterWorkerProtocol.MasterHandling
@@ -13,8 +14,6 @@ import scala.language.postfixOps
 
 object PasswordCrackingMaster {
 
-  val passwordRange: Range = 0 to 1000000
-
   val name = "pc-master"
 
   def props(nWorkers: Int, session: ActorRef): Props = Props(new PasswordCrackingMaster(nWorkers, session))
@@ -23,8 +22,10 @@ object PasswordCrackingMaster {
 
 
 class PasswordCrackingMaster(nWorkers: Int, session: ActorRef) extends Actor with ActorLogging with MasterHandling {
-  import PasswordCrackingMaster._
 
+  private val settings = Settings(context.system)
+
+  val passwordRange: Range = settings.passwordRangeStart to settings.passwordRangeEnd
   val name: String = self.path.name
   val receivedResponses: mutable.Map[ActorRef, Map[Int, Int]] = mutable.Map.empty
 


### PR DESCRIPTION
- new settings file for our own application settings
- `Settings.scala` handling reading of custom settings file
- use these settings in `PasswordCrackingMaster`

**TODO** (after merge of the other PRs #22 #23 #24 and of branch `feature/linearCombination`):
- use settings for linear combination
- use settings for hash mining